### PR TITLE
feat: add open modifier

### DIFF
--- a/src/main/java/com/mparticle/kits/AdobeKit.kt
+++ b/src/main/java/com/mparticle/kits/AdobeKit.kt
@@ -12,7 +12,7 @@ import com.mparticle.media.events.*
 import java.util.*
 import kotlin.collections.HashMap
 
-class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
+open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
 
     internal val LAUNCH_APP_ID: String = "launchAppId"
 


### PR DESCRIPTION
# Summary

a client requested that we make the Adobe Media Kit subclassable. Since the default, final class paradigm is a Kotlin thing and all of the other kits have this property, I think it's in line with our normal standard
