### PR TITLE
feat: Make MediaTracker instance accessable to subclass

### DIFF
--- a/src/main/java/com/mparticle/kits/AdobeKit.kt
+++ b/src/main/java/com/mparticle/kits/AdobeKit.kt
@@ -16,7 +16,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
 
     internal val LAUNCH_APP_ID: String = "launchAppId"
 
-    internal var mediaTracker: MediaTracker? = null
+    protected var mediaTracker: MediaTracker? = null
     private var currentPlayheadPosition: Long = 0
     private var sessionStarted = false
 
@@ -43,7 +43,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
 
     override fun setOptOut(optout: Boolean) = null
 
-    override fun logEvent(p0: MPEvent?) = null
+    override fun logEvent(p0: MPEvent) = null
 
     override fun leaveBreadcrumb(p0: String?) = null
 

--- a/src/test/java/com/adobe/marketing/mobile/MobileCore.kt
+++ b/src/test/java/com/adobe/marketing/mobile/MobileCore.kt
@@ -42,11 +42,10 @@ class Lifecycle: BaseAdobeExtension()
 class Signal: BaseAdobeExtension()
 
 
-class Media: BaseAdobeExtension() {
-    companion object {
-        @JvmStatic
-        fun createTracker(): MediaTracker = MediaTracker()
-    }
+object Media: BaseAdobeExtension() {
+
+    @JvmStatic
+    fun createTracker(): MediaTracker = MediaTracker()
 
     enum class MediaType {
         Video,
@@ -54,5 +53,4 @@ class Media: BaseAdobeExtension() {
     }
 }
 
-class MediaTracker
-
+class MediaTracker { }

--- a/src/test/java/com/mparticle/kits/AdobeMediaKitTests.kt
+++ b/src/test/java/com/mparticle/kits/AdobeMediaKitTests.kt
@@ -4,6 +4,7 @@ package com.mparticle.kits
 import android.app.Application
 import android.content.Context
 import com.adobe.marketing.mobile.Media
+import com.adobe.marketing.mobile.MediaTracker
 import com.adobe.marketing.mobile.MobileCore
 import com.mparticle.media.events.ContentType
 import com.mparticle.media.events.MediaContent
@@ -14,7 +15,10 @@ import java.util.*
 
 class AdobeMediaKitTests {
 
-    private fun getKit() = AdobeKit()
+    private fun getKit() = object: AdobeKit()  {
+        val tracker: MediaTracker?
+            get() { return super.mediaTracker }
+    }
 
     @Test
     fun testGetName() {
@@ -44,7 +48,7 @@ class AdobeMediaKitTests {
     fun testClassName() {
         val factory = KitIntegrationFactory()
         val integrations = factory.getKnownIntegrations()
-        val className = getKit()::class.java.getName()
+        val className = AdobeKit()::class.java.getName()
         assertEquals("$className not found as a known integration.",1, integrations.filterValues { it == className }.count())
     }
 
@@ -63,7 +67,7 @@ class AdobeMediaKitTests {
         kit.onKitCreate(settings, context)
 
         assertEquals(trackingServer, MobileCore.configKey)
-        assertNotNull(kit.mediaTracker)
+        assertNotNull(kit.tracker)
     }
 
     @Test


### PR DESCRIPTION
# Summary

Make MediaTracker instance accessible to subclasses
