### PR TITLE
fix: remove sessionStarted flag to allow concurrent sessions

### DIFF
--- a/src/main/java/com/mparticle/kits/AdobeKit.kt
+++ b/src/main/java/com/mparticle/kits/AdobeKit.kt
@@ -18,7 +18,6 @@ class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
 
     internal var mediaTracker: MediaTracker? = null
     private var currentPlayheadPosition: Long = 0
-    private var sessionStarted = false
 
     override fun getName() = "Adobe Media"
 
@@ -91,11 +90,8 @@ class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     }
 
     private fun sessionStart(mediaEvent: MediaEvent) {
-        if (!sessionStarted) {
-            val mediaInfo = mediaEvent.mediaContent.getMediaObject()
-            mediaTracker?.trackSessionStart(mediaInfo, mediaEvent.customAttributes?.toAdobeAttributes())
-            sessionStarted = true
-        }
+        val mediaInfo = mediaEvent.mediaContent.getMediaObject()
+        mediaTracker?.trackSessionStart(mediaInfo, mediaEvent.customAttributes?.toAdobeAttributes())
     }
 
     private fun sessionEnd() {


### PR DESCRIPTION
# Summary

Remove the `sessionStarted` flag. The current logic is preventing the kit from receiving multiple (since it is never reset to `false`) or concurrent sessions