### PR TITLE
Replace mediaTracker with map of MediaTrackers

### DIFF
--- a/src/main/java/com/mparticle/kits/AdobeKit.kt
+++ b/src/main/java/com/mparticle/kits/AdobeKit.kt
@@ -16,6 +16,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
 
     internal val LAUNCH_APP_ID: String = "launchAppId"
 
+    protected var defaultMediaTracker: MediaTracker? = null
     protected var mediaTrackers: MutableMap<String, MediaTracker?> = mutableMapOf()
     private var currentPlayheadPosition: Long = 0
 
@@ -36,6 +37,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
         MobileCore.start {
             MobileCore.configureWithAppID(appId)
         }
+        defaultMediaTracker = Media.createTracker()
         return listOf()
     }
 
@@ -50,8 +52,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     override fun logScreen(p0: String?, p1: MutableMap<String, String>?) = null
 
     override fun logError(errorString: String?, p1: MutableMap<String, String>?): List<ReportingMessage>? {
-        val tracker = mediaTrackers[p1?.get("media_session_id")]
-        tracker?.trackError(errorString)
+        defaultMediaTracker?.trackError(errorString)
         return null
     }
 
@@ -97,8 +98,9 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     }
 
     private fun sessionEnd(mediaEvent: MediaEvent) {
-        mediaTrackers[mediaEvent.sessionId]?.trackSessionEnd()
-        mediaTrackers[mediaEvent.sessionId] = null
+        val sessionId = mediaEvent.sessionId ?: return
+        mediaTrackers[sessionId]?.trackSessionEnd()
+        mediaTrackers[sessionId] = null
     }
 
     private fun play(mediaEvent: MediaEvent) {

--- a/src/main/java/com/mparticle/kits/AdobeKit.kt
+++ b/src/main/java/com/mparticle/kits/AdobeKit.kt
@@ -17,7 +17,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     internal val LAUNCH_APP_ID: String = "launchAppId"
 
     protected var defaultMediaTracker: MediaTracker? = null
-    protected var mediaTrackers: MutableMap<String, MediaTracker?> = mutableMapOf()
+    protected var mediaTrackers: MutableMap<String, MediaTracker> = mutableMapOf()
     private var currentPlayheadPosition: Long = 0
 
     override fun getName() = "Adobe Media"
@@ -100,7 +100,7 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     private fun sessionEnd(mediaEvent: MediaEvent) {
         val sessionId = mediaEvent.sessionId ?: return
         mediaTrackers[sessionId]?.trackSessionEnd()
-        mediaTrackers[sessionId] = null
+        mediaTrackers.remove(sessionId)
     }
 
     private fun play(mediaEvent: MediaEvent) {

--- a/src/main/java/com/mparticle/kits/AdobeKit.kt
+++ b/src/main/java/com/mparticle/kits/AdobeKit.kt
@@ -114,9 +114,9 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     private fun updateQos(mediaEvent: MediaEvent) {
         mediaEvent.qos?.let { mediaQos ->
             val qoe = Media.createQoEObject(mediaQos.bitRate?.toLong() ?: 0,
-                mediaQos.startupTime?.toSeconds() ?: 0.0,
-                mediaQos.fps?.toDouble() ?: 0.0,
-                mediaQos.droppedFrames?.toLong() ?: 0)
+                    mediaQos.startupTime?.toSeconds() ?: 0.0,
+                    mediaQos.fps?.toDouble() ?: 0.0,
+                    mediaQos.droppedFrames?.toLong() ?: 0)
             mediaTrackers[mediaEvent.sessionId]?.updateQoEObject(qoe)
         }
     }
@@ -177,33 +177,33 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
 
     private fun MediaSegment.getChapterObject(): Map<String?, Any?> {
         return Media.createChapterObject(title,
-            index?.toLong() ?: 0,
-            duration?.toDouble() ?: 0.0,
-            currentPlayheadPosition.toDouble()
+                index?.toLong() ?: 0,
+                duration?.toDouble() ?: 0.0,
+                currentPlayheadPosition.toDouble()
         )
     }
 
     internal fun MediaContent.getMediaObject(): HashMap<String?, Any?> {
         return Media.createMediaObject(
-            name,
-            contentId,
-            duration?.toSeconds() ?: 0.0,
-            streamType,
-            getMediaType()
+                name,
+                contentId,
+                duration?.toSeconds() ?: 0.0,
+                streamType,
+                getMediaType()
         )
     }
 
     internal fun MediaAdBreak.getAdBreakObject(): Map<String?, Any?> {
         return Media.createAdBreakObject(
-            title,
-            1L,
-            currentPlayheadPosition.toSeconds()
+                title,
+                1L,
+                currentPlayheadPosition.toSeconds()
         )
     }
 
     internal fun MediaAd.getAdObject(): Map<String?, Any?> {
         return Media.createAdObject(title, id, position?.toLong() ?: 0, duration?.toDouble()
-            ?: 0.0)
+                ?: 0.0)
     }
 
     internal fun MediaContent.getMediaType(): Media.MediaType? {
@@ -215,30 +215,30 @@ open class AdobeKit: AdobeKitBase(), KitIntegration.EventListener {
     }
 
     internal fun Map<String, String>.toAdobeAttributes(): Map<String, String> =
-        mapKeys { (key, _) ->
-            when (key) {
-                MediaAttributeKeys.AD_ADVERTISING_ID -> AdMetadataKeys.ADVERTISER
-                MediaAttributeKeys.AD_CAMPAIGN -> AdMetadataKeys.CAMPAIGN_ID
-                MediaAttributeKeys.AD_CREATIVE -> AdMetadataKeys.CREATIVE_ID
-                MediaAttributeKeys.AD_PLACEMENT -> AdMetadataKeys.PLACEMENT_ID
-                MediaAttributeKeys.AD_SITE_ID -> AdMetadataKeys.SITE_ID
-                EventAttributes.CONTENT_SHOW -> VideoMetadataKeys.SHOW
-                EventAttributes.CONTENT_EPISODE -> VideoMetadataKeys.EPISODE
-                EventAttributes.CONTENT_ASSET_ID -> VideoMetadataKeys.ASSET_ID
-                EventAttributes.CONTENT_GENRE -> VideoMetadataKeys.GENRE
-                EventAttributes.CONTENT_FIRST_AIR_DATE -> VideoMetadataKeys.FIRST_AIR_DATE
-                EventAttributes.CONTENT_DIGITAL_DATE -> VideoMetadataKeys.FIRST_DIGITAL_DATE
-                EventAttributes.CONTENT_RATING -> VideoMetadataKeys.RATING
-                EventAttributes.CONTENT_ORIGINATOR -> VideoMetadataKeys.ORIGINATOR
-                EventAttributes.CONTENT_NETWORK -> VideoMetadataKeys.NETWORK
-                EventAttributes.CONTENT_SHOW_TYPE -> VideoMetadataKeys.SHOW_TYPE
-                EventAttributes.CONTENT_MVPD -> VideoMetadataKeys.MVPD
-                EventAttributes.CONTENT_AUTHORIZED -> VideoMetadataKeys.AUTHORIZED
-                EventAttributes.CONTENT_DAYPART -> VideoMetadataKeys.DAY_PART
-                EventAttributes.CONTENT_FEED -> VideoMetadataKeys.FEED
-                else -> key
+            mapKeys { (key, _) ->
+                when (key) {
+                    MediaAttributeKeys.AD_ADVERTISING_ID -> AdMetadataKeys.ADVERTISER
+                    MediaAttributeKeys.AD_CAMPAIGN -> AdMetadataKeys.CAMPAIGN_ID
+                    MediaAttributeKeys.AD_CREATIVE -> AdMetadataKeys.CREATIVE_ID
+                    MediaAttributeKeys.AD_PLACEMENT -> AdMetadataKeys.PLACEMENT_ID
+                    MediaAttributeKeys.AD_SITE_ID -> AdMetadataKeys.SITE_ID
+                    EventAttributes.CONTENT_SHOW -> VideoMetadataKeys.SHOW
+                    EventAttributes.CONTENT_EPISODE -> VideoMetadataKeys.EPISODE
+                    EventAttributes.CONTENT_ASSET_ID -> VideoMetadataKeys.ASSET_ID
+                    EventAttributes.CONTENT_GENRE -> VideoMetadataKeys.GENRE
+                    EventAttributes.CONTENT_FIRST_AIR_DATE -> VideoMetadataKeys.FIRST_AIR_DATE
+                    EventAttributes.CONTENT_DIGITAL_DATE -> VideoMetadataKeys.FIRST_DIGITAL_DATE
+                    EventAttributes.CONTENT_RATING -> VideoMetadataKeys.RATING
+                    EventAttributes.CONTENT_ORIGINATOR -> VideoMetadataKeys.ORIGINATOR
+                    EventAttributes.CONTENT_NETWORK -> VideoMetadataKeys.NETWORK
+                    EventAttributes.CONTENT_SHOW_TYPE -> VideoMetadataKeys.SHOW_TYPE
+                    EventAttributes.CONTENT_MVPD -> VideoMetadataKeys.MVPD
+                    EventAttributes.CONTENT_AUTHORIZED -> VideoMetadataKeys.AUTHORIZED
+                    EventAttributes.CONTENT_DAYPART -> VideoMetadataKeys.DAY_PART
+                    EventAttributes.CONTENT_FEED -> VideoMetadataKeys.FEED
+                    else -> key
+                }
             }
-        }
 
     internal fun Long.toSeconds(): Double {
         return toDouble() / 1000

--- a/src/test/java/com/mparticle/kits/AdobeMediaKitTests.kt
+++ b/src/test/java/com/mparticle/kits/AdobeMediaKitTests.kt
@@ -17,7 +17,7 @@ class AdobeMediaKitTests {
 
     private fun getKit() = object: AdobeKit()  {
         val tracker: MediaTracker?
-            get() { return super.mediaTracker }
+            get() { return super.defaultMediaTracker }
     }
 
     @Test


### PR DESCRIPTION
# Summary
`mediaTracker` has been largely replaced by `mediaTrackers: MutableMap<String, MediaTracker?>`, mapping the event's `sessionId` to its `MediaTracker`. This will allow the AdobeKit to support multiple media sessions being active concurrently. This implementation keeps a `defaultMediaTracker` to use in `logError()` until it can be replaced.