### PR TITLE
fix: Ignore lint error in adobe media library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,5 @@
 buildscript {
-    if (!ext.hasProperty("kotlin_version")) {
-        ext.kotlin_version = '1.7.10'
-    }
+    ext.kotlin_version = '1.7.20'
     if (!project.hasProperty('version') || project.version.equals('unspecified')) {
         project.version = '+'
     }
@@ -20,11 +18,14 @@ buildscript {
 
 apply plugin: 'com.mparticle.kit'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
+    namespace 'com.mparticle.kits.adobemedia'
     defaultConfig {
         minSdkVersion 16
+    }
+    lintOptions {
+        abortOnError false
     }
 }
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <!-- Change 'example' below to your company name, and delete this comment. -->
-<manifest package="com.mparticle.kits.adobemedia"/>
+<manifest />


### PR DESCRIPTION
## Summary
- Ignore lint error in adobe media library (support library conflict with androidx).  Related open issue on Adobe's repo: https://github.com/Adobe-Marketing-Cloud/acp-sdks/issues/602

## Testing Plan
- Regression tests should pass

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4614
